### PR TITLE
add expect.any stmnt

### DIFF
--- a/libs/ngrxlib/src/lib/+state/ngrxlib.effects.spec.ts
+++ b/libs/ngrxlib/src/lib/+state/ngrxlib.effects.spec.ts
@@ -46,7 +46,7 @@ describe('NgrxlibEffects', () => {
       });
 
       const expected = hot('-a|', {
-        a: NgrxlibActions.someTestSuccess({ message: 'all good!' }),
+        a: NgrxlibActions.someTestSuccess({ message: expect.any(String) }),
       });
 
       // assert


### PR DESCRIPTION
using `expect....` statements in the objects that get passed into the `toBeObservable(...)` of jasmine-marbles breaks the tests

![image](https://user-images.githubusercontent.com/542458/132028536-7c74ee11-0e1e-4abd-a60c-d77ca9f1ea7b.png)
